### PR TITLE
Fix 'Orbiter' folder import bug.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,11 +22,12 @@
 #   2.0.5       - Fix issues with textures importing.
 #   2.0.6       - Fix issue building multiple scenes.
 #               - Output constexpr in place of macros.
+#   2.0.7       - Fix issue importing from Orbiter folder structure named other than 'Orbiter'.
 
 bl_info = {
     "name": "Orbiter Mesh Tools",
     "author": "Blake Christensen",
-    "version": (2, 0, 6),
+    "version": (2, 0, 7),
     "blender": (2, 81, 0),
     "location": "",
     "description": "Tools for building Orbiter mesh files.",

--- a/import_tools.py
+++ b/import_tools.py
@@ -404,7 +404,7 @@ def import_mesh(config, file_path):
     # find the Orbiter path
     p = Path(file_path)
     up = [pp.lower() for pp in p.parts]
-    orbiter_path = os.path.join(*up[0:up.index('orbiter') + 1])
+    orbiter_path = os.path.join(*up[0:up.index('meshes')])
     print("Orbiter path: {}".format(orbiter_path))
 
     groups, materials, textures = read_mesh_file(config, file_path)


### PR DESCRIPTION
Fixes an issue where you could not import a mesh for an Orbiter folder where the 'Orbiter' base folder had a name other than 'Orbiter'.