### PR TITLE
Import and export bugs.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,11 +25,14 @@
 #   2.0.7       - Fix issue importing from Orbiter folder structure named other than 'Orbiter'.
 #   2.0.8       - Import: Name groups according to LABEL tag.
 #               - Export: Add option to export only selected.
+#   2.0.9       - Import: Allow LABEL/Group names with spaces.
+#               - Export: Handle texture files in sub-folders of 'textures'.
+#               - Export: Fix bug that created too many vertices.
 
 bl_info = {
     "name": "Orbiter Mesh Tools",
     "author": "Blake Christensen",
-    "version": (2, 0, 8),
+    "version": (2, 0, 9),
     "blender": (2, 81, 0),
     "location": "",
     "description": "Tools for building Orbiter mesh files.",

--- a/import_tools.py
+++ b/import_tools.py
@@ -118,7 +118,10 @@ def read_group(file):
     new_group = ImportGroup()
     flag = ""
     while True:
-        parts = file.readline().split()
+        decomment = file.readline().split(';')
+        # If something needs the comment, uncomment below, currently nothing does.
+        # comment = decomment[1] if len(decomment) > 1 else None
+        parts = decomment[0].split()
         if len(parts) == 0:
             continue
         flag = parts[0]
@@ -147,7 +150,7 @@ def read_group(file):
             new_group.flag = parts[1]
 
         if "LABEL" in flag.upper():
-            new_group.name = parts[1]
+            new_group.name = "_".join(parts[1:])
 
         if "GEOM" in flag.upper():
             if len(parts) < 3:


### PR DESCRIPTION
Import: Groups will be named using the mesh group LABEL tag.  Spaces will convert to _.
Export: Textures referenced in sub-folders under Orbiter\Textures will include the proper sub-folder in the mesh file.
Export: Fixed a bug causing too many vertices (duplicates) to be created.  The comparison for 'sameness' was not using a tolerance.  See the 'set_normal' method in orbiter_tools.py if you feel you need to adjust that tolerance.