### PR TITLE
Add support for 2D panel meshes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Orbiter Mesh Tools is a [Blender](https://www.blender.org/) add-on for generating [Orbiter](http://orbit.medphys.ucl.ac.uk/index.html) mesh files.  It will also, optionally, generate a C++ source file for the mesh being created.
 
 ## Compatibility:
-Blender 2.82.
+Blender 2.82 - 3.0.1.
 
 
 ## Getting Started
@@ -66,15 +66,19 @@ If you want to mimic the use of vertex normals, you can do this by telling Blend
 ### Object Panel
 ***Name:*** The name of the currently selected object.
 
-***OrbiterSortOrder:*** Controls the sort order for the object in the mesh file.  Default is 50.  Higher numbers will move that object later in the mesh file.  This is used to control render order of transparent objects.  An object with transparency should be given a higher value then other objects it may appear in front of.
+***Sort Order:*** Controls the sort order for the object in the mesh file.  Default is 50.  Higher numbers will move that object later in the mesh file.  This is used to control render order of transparent objects.  An object with transparency should be given a higher value then other objects it may appear in front of.
 
-***OrbiterMeshFlag:*** Sets the Orbiter mesh flag value.  See Orbiter SDK for values.
+***Mesh Flag:*** Sets the Orbiter mesh flag value.  See Orbiter SDK for values.
 
-***Output Location:*** Output object location as a const VECTOR3 value.
+***Include Position:*** Output object location as a const VECTOR3 value.
 
-***Output Vertex Array:*** Output the object vertices as an array of NTVERTEX values.
+***Include Vertex Array:*** Output the object vertices as an array of NTVERTEX values.
 
 ***Output quad:*** If the object is a plane it will output VECTOR3 values for each corner.  These can be used to setup a ‘hit’ rectangle.
+
+***Include Width and Height:*** Output a width and height variable for the object in the include file.  Width is the size of the X axis, and height is the Y axis.  Useful for 2d panel development.
+
+***Output
 
 ### Material Panel
 ***Diffuse Color:*** Orbiter diffuse color.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ Blender 2.82.
 
 
 ## Getting Started
-1.	Click on the 'Clone or Download' in Github and select Download ZIP.
-2.	In Blender open *User Preferences* and go to the *Add Ons* tab.
-3.	Select 'Install' at the top of the Preferences window and find the orbiter-blender-master.zip file and click the 'Install Add-on' button.
-4.  Click the check box next to the add on name 'Import-Export: Orbiter Mesh Tools' to enable the add-on.
-5.  Read the included 'Orbiter Tools Tutorial.pdf' document for a tutorial on how to create a simple textured vessel for Orbiter using this plugin.
+1.	Under _Releases_ above, click on the _Latest_ release.  This will open the Release page.
+2.  Under _Assets_ click on _Source code (zip)_.  This will download a zip file to your PC.
+3.	In Blender open *User Preferences* and go to the *Add Ons* tab.
+4.	Select _Install_ at the top of the Preferences window and find the zip file you just download, and click the _Install Add-on_ button.
+5.  Click the check box next to the add on name _Import-Export: Orbiter Mesh Tools_ to enable the add-on.
+6.  Read the included _Orbiter Tools Tutorial.pdf_ document for a tutorial on how to create a simple textured vessel for Orbiter using this plugin.
 
 
 ## General Usage

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Orbiter Mesh Tools is a [Blender](https://www.blender.org/) add-on for generating [Orbiter](http://orbit.medphys.ucl.ac.uk/index.html) mesh files.  It will also, optionally, generate a C++ source file for the mesh being created.
 
 ## Compatibility:
-Blender 2.82 - 3.0.1.
+Blender 2.82 - 3.5.0.
 
 
 ## Getting Started
@@ -63,6 +63,8 @@ If you want to mimic the use of vertex normals, you can do this by telling Blend
 
 ***Scene Namespace:*** The namespace for values from this scene that will be written to the include file.  By default this will be the name of the scene but can be changed to whatever is convenient.
 
+***Is Scene 2D Panel:*** If checked, this scene will adjust the axis values so that the mesh file for this scene can be used as a 2D panel.  
+
 ### Object Panel
 ***Name:*** The name of the currently selected object.
 
@@ -77,6 +79,8 @@ If you want to mimic the use of vertex normals, you can do this by telling Blend
 ***Output quad:*** If the object is a plane it will output VECTOR3 values for each corner.  These can be used to setup a ‘hit’ rectangle.
 
 ***Include Width and Height:*** Output a width and height variable for the object in the include file.  Width is the size of the X axis, and height is the Y axis.  Useful for 2d panel development.
+
+***Include RECT:*** Output a RECT structure for this object.  Assumes the object is a simple plane with four vertices.
 
 ***Output
 

--- a/__init__.py
+++ b/__init__.py
@@ -84,7 +84,7 @@ class OrbiterBuildMesh(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.mode is not 'EDIT_MESH'
+        return context.mode != 'EDIT_MESH'
 
     def execute(self, context):
         print("Orbiter Build Mesh called.")
@@ -184,7 +184,7 @@ class IMPORT_OT_OrbiterMesh(bpy.types.Operator, ImportHelper):
 
     @classmethod
     def poll(cls, context):
-        return context.mode is not 'EDIT_MESH'
+        return context.mode != 'EDIT_MESH'
 
     def execute(self, context):
         print("Import Orbiter Mesh started.")

--- a/__init__.py
+++ b/__init__.py
@@ -33,11 +33,12 @@
 #   2.0.11      - Export: Add Sort method that allows mesh group sort by name.
 #               - Export: When exporting selected objects, only include those materials/textures in file.
 #   2.0.12      - Export: Fix material sort order issue.
+#   2.1.0       - Export: Add support for 2D panel mesh scenes.
 
 bl_info = {
     "name": "Orbiter Mesh Tools",
     "author": "Blake Christensen",
-    "version": (2, 0, 12),
+    "version": (2, 1, 0),
     "blender": (2, 81, 0),
     "location": "",
     "description": "Tools for building Orbiter mesh files.",
@@ -374,6 +375,8 @@ class OBJECT_PT_OrbiterScene(bpy.types.Panel):
         row.prop(scene, "orbiter_create_mesh_file")
         row = layout.row()
         row.prop(scene, "orbiter_scene_namespace")
+        row = layout.row()
+        row.prop(scene, "orbiter_is_2d_panel")
 
 
 classes = {
@@ -429,6 +432,10 @@ def register():
     bpy.types.Scene.orbiter_scene_namespace = bpy.props.StringProperty(
         name="Scene Namespace",
         description="Namespace for this scene in the include file")
+    bpy.types.Scene.orbiter_is_2d_panel = bpy.props.BoolProperty(
+        name="Is Scene 2D panel",
+        description="If True, modifies UV values for flat panel textures.",
+        default=False)
 
     # These props are only referenced from scene[0] this
     # seems to be the best place to put general settings.
@@ -541,6 +548,7 @@ def unregister():
     del bpy.types.Scene.orbiter_create_mesh_file
     del bpy.types.Scene.orbiter_scene_namespace
     del bpy.types.Scene.orbiter_build_include_file
+    del bpy.types.Scene.orbiter_is_2d_panel    
     del bpy.types.Scene.orbiter_verbose
     del bpy.types.Scene.orbiter_include_path
     del bpy.types.Scene.orbiter_mesh_path

--- a/__init__.py
+++ b/__init__.py
@@ -34,11 +34,12 @@
 #               - Export: When exporting selected objects, only include those materials/textures in file.
 #   2.0.12      - Export: Fix material sort order issue.
 #   2.1.0       - Export: Add support for 2D panel mesh scenes.
+#   2.1.1       - Fix issue with mesh to world transform not picking up normals.
 
 bl_info = {
     "name": "Orbiter Mesh Tools",
     "author": "Blake Christensen",
-    "version": (2, 1, 0),
+    "version": (2, 1, 1),
     "blender": (2, 81, 0),
     "location": "",
     "description": "Tools for building Orbiter mesh files.",

--- a/__init__.py
+++ b/__init__.py
@@ -302,6 +302,8 @@ class OBJECT_PT_OrbiterObject(bpy.types.Panel):
         if obj.type == 'MESH':
             row = layout.row()
             row.prop(obj, "orbiter_include_quad", text="Output quad.")
+            row = layout.row()
+            row.prop(obj, "orbiter_include_size", text="Include width and height.")
 
 
 class OBJECT_PT_OrbiterOutput(bpy.types.Panel):
@@ -422,6 +424,10 @@ def register():
     bpy.types.Object.orbiter_include_vertex_array = bpy.props.BoolProperty(
         name="Include Vertex Array",
         description="Include object vertices as an array of NTVERTEX values.",
+        default=False)
+    bpy.types.Object.orbiter_include_size = bpy.props.BoolProperty(
+        name="Include Width and Height",
+        description="Include object width and height in Blender units.",
         default=False)
 
     # Scene properties:
@@ -565,6 +571,7 @@ def unregister():
     del bpy.types.Material.orbiter_emit_color
     del bpy.types.Object.orbiter_include_quad
     del bpy.types.Object.orbiter_include_vertex_array
+    del bpy.types.Object.orbiter_include_size
     del bpy.types.Object.orbiter_mesh_flag
     del bpy.types.Material.orbiter_is_dynamic
 

--- a/__init__.py
+++ b/__init__.py
@@ -304,6 +304,8 @@ class OBJECT_PT_OrbiterObject(bpy.types.Panel):
             row.prop(obj, "orbiter_include_quad", text="Output quad.")
             row = layout.row()
             row.prop(obj, "orbiter_include_size", text="Include width and height.")
+            row = layout.row()
+            row.prop(obj, "orbiter_include_rect", text="Include RECT.")
 
 
 class OBJECT_PT_OrbiterOutput(bpy.types.Panel):
@@ -428,6 +430,10 @@ def register():
     bpy.types.Object.orbiter_include_size = bpy.props.BoolProperty(
         name="Include Width and Height",
         description="Include object width and height in Blender units.",
+        default=False)
+    bpy.types.Object.orbiter_include_rect = bpy.props.BoolProperty(
+        name="Include RECT",
+        description="Include object RECT based on X-Z dimensions and centered origin.",
         default=False)
 
     # Scene properties:
@@ -572,6 +578,7 @@ def unregister():
     del bpy.types.Object.orbiter_include_quad
     del bpy.types.Object.orbiter_include_vertex_array
     del bpy.types.Object.orbiter_include_size
+    del bpy.types.Object.orbiter_include_rect
     del bpy.types.Object.orbiter_mesh_flag
     del bpy.types.Material.orbiter_is_dynamic
 

--- a/orbiter_tools.py
+++ b/orbiter_tools.py
@@ -112,7 +112,8 @@ class Vertex:
     @classmethod
     def from_BlenderVertex(cls, blvert, world_matrix, swap_axis=True, is_2d_panel=False):
         nv = cls()
-        tv = world_matrix @ blvert.co  #  Transform
+        #tv = world_matrix @ blvert.co  #  Transform
+        tv = blvert.co
 
         # Handle the permutations of swap_axis and is_2d_panel.
         
@@ -362,6 +363,7 @@ class MeshGroup:
         object_eval = mesh_object.evaluated_get(depsgraph=deps)
         temp_mesh = object_eval.to_mesh()
         temp_mesh.validate()  # To fix a possibly invalid mesh.  This seems to help.
+        temp_mesh.transform(self.matrix_world)
         temp_mesh.calc_loop_triangles()  #  Orbiter needs triangles, so turn all polygons to tris.
         
         #  Calc split normals here, even if not using auto smooth, this will put

--- a/orbiter_tools.py
+++ b/orbiter_tools.py
@@ -562,7 +562,15 @@ def build_include(config, scene, groups, texNames):
             config.write_to_include('    const double {}_Width = {};\n'.format(object.name, object.dimensions.x))
             config.write_to_include('    const double {}_Height = {};\n'.format(object.name, object.dimensions.z))
 
-            
+        if object.orbiter_include_rect:
+            # for now, assuming a principal plane of X-Z
+            rleft = object.location.x - object.dimensions.x / 2
+            rright = object.location.x + object.dimensions.x / 2
+            rtop = 0 - (object.location.z + object.dimensions.z / 2)
+            rbot = 0 - (object.location.z - object.dimensions.z / 2)
+            config.write_to_include(
+                        '    constexpr RECT {}_RC = {{{:d}, {:d}, {:d}, {:d}}};\n'.format(
+                            object.name, int(rleft), int(rtop), int(rright), int(rbot)))
 
                 
     config.write_to_include("\n  }\n")    # close namespace

--- a/orbiter_tools.py
+++ b/orbiter_tools.py
@@ -115,22 +115,47 @@ class Vertex:
         tv = world_matrix @ blvert.co  #  Transform
 
         # Handle the permutations of swap_axis and is_2d_panel.
-        if swap_axis and not is_2d_panel:
+        
+        # Normal mesh, no 2d panel:
+        # swap_axis=true (default) means we need to swap the y and z
+        # values.  If false, we need to modify x to be the negative
+        # value (opposite) so that the handedness matches Orbiter.
+        # 2d panel:
+        
+        # For 2d_panels, if swap_axis=true, we assume the panel mesh
+        # is laid out in the z/x plane, with the mesh extending down
+        # from the x axis.  This is for convenience in modelling.  In
+        # that case, we leave x as is, and replace y with the -z axis
+        # (oposite sign).
+        # For swap_axis=false, we assume the panel is laid out in the 
+        # x/y plane with the x values in the negative x plane.  In this
+        # case we need to swap the x values to get correct handedness.
+
+        if swap_axis:
             nv.x = tv.x
-            nv.y = tv.z
-            nv.z = tv.y
-        elif swap_axis and is_2d_panel:
-            nv.x = tv.x
-            nv.y = -tv.z
-            nv.z = 0.0
-        elif is_2d_panel and not swap_axis:
-            nv.x = tv.x
-            nv.y = tv.y
-            nv.z = 0.0
+            nv.y = -tv.z if is_2d_panel else tv.z
+            nv.z = 0.0 if is_2d_panel else tv.y
         else:
-            nv.x = -tv.x
+            nv.x = tv.x if is_2d_panel else -tv.x
             nv.y = tv.y
-            nv.z = tv.z
+            nv.z = 0.0 if is_2d_panel else tv.z
+
+        # if swap_axis and not is_2d_panel:
+        #     nv.x = tv.x
+        #     nv.y = tv.z
+        #     nv.z = tv.y
+        # elif swap_axis and is_2d_panel:
+        #     nv.x = tv.x
+        #     nv.y = -tv.z
+        #     nv.z = 0.0
+        # elif is_2d_panel and not swap_axis:
+        #     nv.x = tv.x
+        #     nv.y = tv.y
+        #     nv.z = 0.0
+        # else:
+        #     nv.x = -tv.x
+        #     nv.y = tv.y
+        #     nv.z = tv.z
         
         nv.world_matrix = world_matrix
         return nv
@@ -143,23 +168,34 @@ class Vertex:
         nv.z = Vertex.z
 
         # Handle the permutations of swap_axis and is_2d_panel.
-        if normal:
-            if swap_axis and not is_2d_panel:
-                nv.nx = normal.x
-                nv.ny = normal.z
-                nv.nz = normal.y
-            elif swap_axis and is_2d_panel:
-                nv.nx = normal.x
-                nv.ny = -normal.z
-                nv.nz = 0.0
-            elif is_2d_panel and not swap_axis:
-                nv.nx = normal.x
-                nv.ny = normal.y
-                nv.nz = 0.0
-            else:
-                nv.nx = -normal.x
-                nv.ny = normal.y
-                nv.nz = normal.z
+        # Same as from_BlenderVertex (above), see notes.
+
+        if swap_axis:
+            nv.nx = normal.x
+            nv.ny = -normal.z if is_2d_panel else normal.z
+            nv.nz = 0.0 if is_2d_panel else normal.y
+        else:
+            nv.nx = normal.x if is_2d_panel else -normal.x
+            nv.ny = normal.y
+            nv.nz = 0.0 if is_2d_panel else normal.z
+
+        # if normal:
+        #     if swap_axis and not is_2d_panel:
+        #         nv.nx = normal.x
+        #         nv.ny = normal.z
+        #         nv.nz = normal.y
+        #     elif swap_axis and is_2d_panel:
+        #         nv.nx = normal.x
+        #         nv.ny = -normal.z
+        #         nv.nz = 0.0
+        #     elif is_2d_panel and not swap_axis:
+        #         nv.nx = normal.x
+        #         nv.ny = normal.y
+        #         nv.nz = 0.0
+        #     else:
+        #         nv.nx = -normal.x
+        #         nv.ny = normal.y
+        #         nv.nz = normal.z
         
         if uv:
             nv.u = uv[0]

--- a/orbiter_tools.py
+++ b/orbiter_tools.py
@@ -115,10 +115,18 @@ class Vertex:
         tv = world_matrix @ blvert.co  #  Transform
 
         # Handle the permutations of swap_axis and is_2d_panel.
-        if swap_axis:
+        if swap_axis and not is_2d_panel:
             nv.x = tv.x
             nv.y = tv.z
             nv.z = tv.y
+        elif swap_axis and is_2d_panel:
+            nv.x = tv.x
+            nv.y = -tv.z
+            nv.z = 0.0
+        elif is_2d_panel and not swap_axis:
+            nv.x = tv.x
+            nv.y = tv.y
+            nv.z = 0.0
         else:
             nv.x = -tv.x
             nv.y = tv.y
@@ -136,10 +144,18 @@ class Vertex:
 
         # Handle the permutations of swap_axis and is_2d_panel.
         if normal:
-            if swap_axis:
+            if swap_axis and not is_2d_panel:
                 nv.nx = normal.x
                 nv.ny = normal.z
                 nv.nz = normal.y
+            elif swap_axis and is_2d_panel:
+                nv.nx = normal.x
+                nv.ny = -normal.z
+                nv.nz = 0.0
+            elif is_2d_panel and not swap_axis:
+                nv.nx = normal.x
+                nv.ny = normal.y
+                nv.nz = 0.0
             else:
                 nv.nx = -normal.x
                 nv.ny = normal.y
@@ -188,7 +204,7 @@ class Vertex:
 
         nu = uv[0]
         #nv = uv[1] if panel_adjust else (1 - uv[1])
-        nv = uv[1] if panel_adjust else (1 - uv[1])
+        nv = (1 - uv[1])
 
         if (self.u is None) or (self.v is None):
             self.u = nu


### PR DESCRIPTION
Add support for creating 2D panel meshes in Blender.

Create a new Scene in Blender for the 2D mesh.  Orbiter expects a 2D panel mesh to be laid out in the X-Y plane with Z = 0.  Since we swap YZ axis (option) we want to layout the panel mesh in the X-Z plane.  Then check the Scene option 'Is Scene 2D pane'.  That will cause the mesh builder to fix up the mesh values so that you can work on the 2D mesh with Z-UP, X-Right orientation.

Orbiter expects the metrics of the mesh to the screen resolution, therefore your Panel mesh will be MUCH bigger in Blender then your other meshes.  This can be a bit of a hassle moving between scenes.