### PR TITLE
Add exclude hidden for render.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you want to mimic the use of vertex normals, you can do this by telling Blend
 
 ***Sort Mode:***  Select the sort mode for the exported groups.  *Sort Order* (default) sort the groups based on the Sort Order property in the Blender object.  *Group Name ASC* sort the groups by group name in ascending order.  *Group Name DESC* sort the groups by name in descending order.
 
+***Exclude Hidden From Render:***  If selected, only objects marked to be visible in a render (the camera icon in the outliner) will be exported to the mesh file.  This is a universal setting and will impact all scenes.  If an include file is generated, any location and size data requested for that object will still be included in the output.  This allows you to create objects that can be used for sizing and position in C++ code, but not actually exist in the mesh.  Similar to an 'Empty', but probably more useful.
+
 ***Build Mesh:*** Initiates the process to build the mesh and include files as configured.  A ‘Blender Alert’ will display when the process is complete.
 
 ### Scene Panel

--- a/__init__.py
+++ b/__init__.py
@@ -35,11 +35,13 @@
 #   2.0.12      - Export: Fix material sort order issue.
 #   2.1.0       - Export: Add support for 2D panel mesh scenes.
 #   2.1.1       - Fix issue with mesh to world transform not picking up normals.
+#   2.1.2       - Export: Add new property 'Exclude objects 'hidden from render' from the mesh file.
+#               - Fix logging issue to get the object name being exported.
 
 bl_info = {
     "name": "Orbiter Mesh Tools",
     "author": "Blake Christensen",
-    "version": (2, 1, 1),
+    "version": (2, 1, 2),
     "blender": (2, 81, 0),
     "location": "",
     "description": "Tools for building Orbiter mesh files.",
@@ -104,7 +106,8 @@ class OrbiterBuildMesh(bpy.types.Operator):
                 name_pattern_id=home_scene.orbiter_id_name_pattern,
                 export_selected=home_scene.orbiter_export_selected,
                 swap_yz=home_scene.orbiter_swap_yz,
-                sort_method=home_scene.orbiter_export_sortmode) as config:
+                sort_method=home_scene.orbiter_export_sortmode,
+                exclude_hidden_render=home_scene.orbiter_exclude_hidden_from_render) as config:
             
             config.log_line("Orbiter Tools Build Log - Date: {}".format(time.asctime()))
             config.log_line("Versions  Blender: {}  Blender Tools: {}".format(
@@ -115,6 +118,7 @@ class OrbiterBuildMesh(bpy.types.Operator):
             config.log_line("Export selected: {}".format(config.export_selected))
             config.log_line("Swap YZ Axis: {}".format(config.swap_yz))
             config.log_line("Sorting method: {}".format(config.sort_method))
+            config.log_line("Exclude hidden for render objects: {}".format(config.exclude_hidden_render))
             if (config.build_include_file):
                 config.log_line("Include Path File: " + config.include_path_file)
                 config.log_line("Id name pattern: " + config.name_pattern_id)
@@ -362,6 +366,8 @@ class OBJECT_PT_OrbiterOutput(bpy.types.Panel):
         row = layout.row()
         row.prop(props_scene, "orbiter_export_sortmode")
         row = layout.row()
+        row.prop(props_scene, "orbiter_exclude_hidden_from_render")
+        row = layout.row()
         row.operator("orbiter.buildmesh", text="Build Mesh")
 
 
@@ -502,8 +508,11 @@ def register():
             ("GROUPNAMEASC", "Group Name ASC", "Sort by Group Name in ascending order"),
             ("GROUPNAMEDESC", "Group Name DESC", "Sort by Group Name in descending order")
         ],
-        default="SORTORDER"
-    )
+        default="SORTORDER")
+    bpy.types.Scene.orbiter_exclude_hidden_from_render = bpy.props.BoolProperty(
+        name="Exclude Hidden From Render",
+        description="Exclude an object from export mesh if hidden from render.",
+        default=False)
 
 
     # Material properties:
@@ -572,6 +581,7 @@ def unregister():
     del bpy.types.Scene.orbiter_export_selected
     del bpy.types.Scene.orbiter_swap_yz
     del bpy.types.Scene.orbiter_export_sortmode
+    del bpy.types.Scene.orbiter_exclude_hidden_from_render
     del bpy.types.Material.orbiter_ambient_color
     del bpy.types.Material.orbiter_specular_color
     del bpy.types.Material.orbiter_specular_power


### PR DESCRIPTION
Add a new global setting that when enabled will exclude from the mesh file any object that has been marked to be hidden (disabled) in renders.