### PR TITLE
Import material name option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,6 @@ Import an Orbiter mesh file by selecting 'File - Import - Orbiter Mesh Import' i
 
 A new Blender scene will be created with the name of the mesh file.  By default, axis values are treated as explaned above, with _Y_ and _Z_ coordinates swapped.  Disable this swap by un-checking the Swap YZ Axis option on the import screen.
 
-A node based material will be created for each unique Material + Texture combination found in the mesh file.  The import process will look for textures in the Orbiter\Textures\ folder, so if you have renamed your Orbiter folder the import may fail.
+A node based material will be created for each unique Material + Texture combination found in the mesh file.  The name of the material will be the imported material name plus the texture name plus the scene name.  This naming can be disabled by setting the import option 'Concatenate material name' to false (default true).  Disable this will cause the resulting material names to have a numeric suffix if used with different textures.  The import process will look for textures in the Orbiter\Textures\ folder, so if you have renamed your Orbiter folder the import may fail.  
 
 Normals are imported as 'split', not 'vertex' normals.  Split normals are more versatile and easier to edit.

--- a/__init__.py
+++ b/__init__.py
@@ -39,11 +39,12 @@
 #               - Fix logging issue to get the object name being exported.
 #   2.1.3       - Export: Add new property 'parse material name'.
 #               - Fix path issue importing under linux.
+#   2.1.4       - Import: Add option to disable concatenation of material name using texture and scene.
 
 bl_info = {
     "name": "Orbiter Mesh Tools",
     "author": "Blake Christensen",
-    "version": (2, 1, 3),
+    "version": (2, 1, 4),
     "blender": (2, 81, 0),
     "location": "",
     "description": "Tools for building Orbiter mesh files.",
@@ -190,6 +191,12 @@ class IMPORT_OT_OrbiterMesh(bpy.types.Operator, ImportHelper):
             description="Swap Y and Z axis values.",
             default=True,
             )
+    
+    orbiter_tools_import_concat_matname: BoolProperty(
+            name="Concatenate material name",
+            description="When true, builds the material name using the object texture and scene to ensure uniqueness.",
+            default=True,
+            )
 
     @classmethod
     def poll(cls, context):
@@ -200,7 +207,8 @@ class IMPORT_OT_OrbiterMesh(bpy.types.Operator, ImportHelper):
 
         with import_tools.OrbiterImportSettings(
                 verbose=self.orbitertools_import_verbose,
-                swap_yz=self.orbitertools_import_swap_yz) as config:
+                swap_yz=self.orbitertools_import_swap_yz,
+                concat_mat=self.orbiter_tools_import_concat_matname) as config:
 
             paths = [os.path.join(self.directory, name.name) for name in self.files]
             if not paths:
@@ -246,6 +254,7 @@ class ORBITERTOOLS_PT_import_mesh(bpy.types.Panel):
 
         layout.prop(operator, "orbitertools_import_verbose")
         layout.prop(operator, "orbitertools_import_swap_yz")
+        layout.prop(operator, "orbiter_tools_import_concat_matname")
 
 
 class OBJECT_PT_OrbiterMaterial(bpy.types.Panel):

--- a/import_tools.py
+++ b/import_tools.py
@@ -26,10 +26,12 @@ class OrbiterImportSettings:
 
     def __init__(self,
                  verbose=False,
-                 swap_yz=True):
+                 swap_yz=True,
+                 concat_mat=True):
 
         self.verbose = verbose
         self.swap_yz = swap_yz
+        self.concat_mat=concat_mat
         
         self.log_file_path = orbiter_tools.build_file_path(
             orbiter_tools.get_log_folder(), "BlenderTools", ".log")
@@ -347,12 +349,20 @@ def build_mat_textures(
         src_tex = textures[mt[1]][0]  # tuple, [0] is the texture name
         src_tex_file = ""
         if src_tex:   # Material has a texture
-            mat_name = "{}_{}_{}".format(
-                src_mat.name, src_tex.split(".")[0], scene_name)
+            if config.concat_mat:
+                mat_name = "{}_{}_{}".format(
+                    src_mat.name, src_tex.split(".")[0], scene_name)
+            else:
+                mat_name = src_mat.name
+
             src_tex_file = resolve_texture_path(config, orbiter_path, src_tex)
             print("Tex: {}".format(src_tex_file))
         else:
-            mat_name = "{}_{}".format(src_mat.name, scene_name)
+            if config.concat_mat:
+                mat_name = "{}_{}".format(src_mat.name, scene_name)
+            else:
+                mat_name = src_mat.name
+                
         #  Note: Blender will truncate material names at 64, so mat_name
         #  may not be the actual name.  Use new_mat.name in the dictionary.
         new_mat = bpy.data.materials.new(mat_name)


### PR DESCRIPTION
Add an option to disable the concatenation of material name when importing.  This will just use the material name which will lead to naming collisions of the given material is used with different textures.